### PR TITLE
common.html：

### DIFF
--- a/src/main/resources/static/frontendapp/js/shopping/cartAndHeaderUnion.js
+++ b/src/main/resources/static/frontendapp/js/shopping/cartAndHeaderUnion.js
@@ -1,11 +1,13 @@
 let { createApp, ref, computed, onMounted, toRaw  } = Vue;
 
-// var memberId = document.getElementById("memberId").value;
-const memberId = 1;
+const memberId = document.getElementById("memberId").value;
+// const memberId = 1;
 
 const cartURL = "/api/cart/";
 const productURL = "/images/product_pic/";
 const couponURL = "/api/coupon/";
+const coupons = [];
+
 
 const mockProducts = {
     1001: {
@@ -26,29 +28,27 @@ const mockShoppingCart = [
 let products = mockProducts;
 const cartViewData = ref(mockShoppingCart);
 
-// const cartViewForDropDown = ref([{ proAmount: 0, proPrice: 0}]);
-const coupons = [];
-
 let cartPrdList, cartList, cartPrd;
+if(memberId !== "") {
+    fetchCartAPI().then(
+        cartData => {
+            cartPrdList = cartData.cartPrdList;
+            cartList = cartData.cartList;
+            // console.log(cartPrdList);
+            // console.log(cartList);
 
-fetchCartAPI().then(
-    cartData => {
-        cartPrdList = cartData.cartPrdList;
-        cartList = cartData.cartList;
-        // console.log(cartPrdList);
-        // console.log(cartList);
-
-        products = cartPrdList.reduce(reduceToProducts, {})
-        cartViewData.value = cartList.map(cartView);
+            products = cartPrdList.reduce(reduceToProducts, {})
+            cartViewData.value = cartList.map(cartView);
 
 
-        // console.log("cartViewForDropDown : ", toRaw(cartViewForDropDown.value));
-        console.log("Items : ", toRaw(cartViewData.value));
-    }
-)
-fetchCouponAPI().then(
-    couponData => coupons.push(...couponData)
-)
+            // console.log("cartViewForDropDown : ", toRaw(cartViewForDropDown.value));
+            console.log("Items : ", toRaw(cartViewData.value));
+        }
+    );
+    fetchCouponAPI().then(
+        couponData => coupons.push(...couponData)
+    );
+}
 
 //計算購物車旁數字
 const ttcount  = computed(()=>{
@@ -60,15 +60,11 @@ const allShoppingCartSum = computed(()=>{
 
 const headerComponent = createApp({
     setup() {
-        const hideCartDropDown = ()=>{
-            const element = $("#cart-dropdown").hide();
-        };
 
         return {
             ttcount,
             carts: cartViewData,
             sum: allShoppingCartSum,
-            hideCartDropDown
         }
     }
 }).mount('#vue-header')

--- a/src/main/resources/templates/frontendapp/components/common.html
+++ b/src/main/resources/templates/frontendapp/components/common.html
@@ -176,7 +176,7 @@
                                         </table>
                                     </li>
                                     <li class="buttons w-100 float-left">
-                                        <form action="../cart.html">
+                                        <form action="/cart">
                                             <input class="btn pull-left mt_10 btn-primary btn-rounded w-100"
                                                    value="查看購物車" type="submit">
                                         </form>


### PR DESCRIPTION
修正在某些網址下，比如去個人會員中心(http://localhost:8080/member/{memberId}/account)，此時如果點右上角購物車 drop-down 裡的「前往購物車」按鈕，那會錯誤導入到 (http://localhost:8080/member/cart.html) 網址。 修正這個小 bug。

cartAndHeaderUnion.js:
一，忘記關掉測試時，把 memberId 鎖死為1。造成其它會員如果登入，看不到購物車，以為有 bug。其它是當時都只顯示會員 1 的購物車。已修正。

二，加上測試是否有 memberId，如果 memberId 為空字串時，那就不 fetch 後端資料。 （沒登入時，按下前往購物車，好像要提示請登入？不確定）

三，vue-header 中的 hideCartDropDown 這函數其實已經沒在使用，將其刪去，減少冗餘代碼。