### PR TITLE
cartAndHeaderUnion.js:

### DIFF
--- a/src/main/resources/static/frontendapp/js/shopping/cartAndHeaderUnion.js
+++ b/src/main/resources/static/frontendapp/js/shopping/cartAndHeaderUnion.js
@@ -28,7 +28,7 @@ const mockShoppingCart = [
 let products = mockProducts;
 const cartViewData = ref(mockShoppingCart);
 
-let cartPrdList, cartList, cartPrd;
+let cartPrdList, cartList;
 if(memberId !== "") {
     fetchCartAPI().then(
         cartData => {
@@ -41,7 +41,6 @@ if(memberId !== "") {
             cartViewData.value = cartList.map(cartView);
 
 
-            // console.log("cartViewForDropDown : ", toRaw(cartViewForDropDown.value));
             console.log("Items : ", toRaw(cartViewData.value));
         }
     );


### PR DESCRIPTION
一，加上測試是否有 memberId，如果 memberId 為空字串時，那就不 fetch 後端資料。 （沒登入時，按下前往購物車，好像要提示請登入？不確定）

二，vue-header 中的 hideCartDropDown 這函數其實已經沒在使用，將其刪去，減少冗餘代碼。

補充上個 commit 在 common.html 中：
修正在某些網址下，比如去個人會員中心(http://localhost:8080/member/{memberId}/account)，此時如果點右上角購物車 drop-down 裡的「前往購物車」按鈕，那會錯誤導入到 (http://localhost:8080/member/cart.html) 網址。 修正這個小 bug。